### PR TITLE
fix vue3 useClickHandler.js& go cors

### DIFF
--- a/golang/internal/app/cors.go
+++ b/golang/internal/app/cors.go
@@ -6,7 +6,7 @@ func CORS(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Api-Key")
 		h.ServeHTTP(w, r)
 	})
 }

--- a/web/vue/src/components/click-text-capt.vue
+++ b/web/vue/src/components/click-text-capt.vue
@@ -18,10 +18,10 @@ import {ref} from "vue";
 const domRef = ref(null)
 
 const handler = useHandler(domRef, {
-  // getApi: "/api/go-captcha-data/click-basic",
-  // checkApi: "/api/go-captcha-check-data/click-basic"
-  getApi: "get-data?id=click_dark_en",
-  checkApi: "/api/go-captcha-check-data/click-basic"
+   getApi: "/api/go-captcha-data/click-basic",
+   checkApi: "/api/go-captcha-check-data/click-basic"
+  //getApi: "get-data?id=click_dark_en",
+  //checkApi: "/api/go-captcha-check-data/click-basic"
 })
 
 const clickevnt = (x, y) => {

--- a/web/vue/src/hooks/useClickHandler.js
+++ b/web/vue/src/hooks/useClickHandler.js
@@ -37,9 +37,9 @@ export const useHandler = (domRef, config) => {
       }
     }).then((response)=>{
       const {data = {}} = response;
-      if (!Lodash.isEmpty(data) && (data['code'] || 0) === 200) {
-        cData.image = data['master_image_base64'] || ''
-        cData.thumb = data['thumb_image_base64'] || ''
+      if (!Lodash.isEmpty(data) && (data['code'] || 0) === 0) {
+        cData.image = data['image_base64'] || ''
+        cData.thumb = data['thumb_base64'] || ''
         cData.captKey = data['captcha_key'] || ''
       } else {
         message.warning(`get data failed`)


### PR DESCRIPTION
1.修复go-captcha-example/web/vue/src/hooks/useClickHandler.js中requestCaptchaData函数请求验证码数据失败的问题；
2.修复go-captcha-example/golang/internal/app/cors.go中Access-Control-Allow-Headers，添加,X-Api-Key